### PR TITLE
Update templates in line with latest game version

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 ppy Pty Ltd <contact@ppy.sh>.
+Copyright (c) 2021 ppy Pty Ltd <contact@ppy.sh>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/osu.Game.Templates.csproj
+++ b/osu.Game.Templates.csproj
@@ -8,7 +8,7 @@
     <PackageProjectUrl>https://github.com/ppy/osu-templates</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ppy/osu-templates</RepositoryUrl>
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
-    <copyright>Copyright (c) 2019 ppy Pty Ltd</copyright>
+    <copyright>Copyright (c) 2021 ppy Pty Ltd</copyright>
     <Description>Templates to use when creating a ruleset for consumption in osu!.</Description>
     <PackageTags>dotnet-new;templates;osu</PackageTags>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/TestSceneOsuPlayer.cs
+++ b/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/TestSceneOsuPlayer.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.EmptyFreeform.Tests
     [TestFixture]
     public class TestSceneOsuPlayer : PlayerTestScene
     {
-        public TestSceneOsuPlayer()
-            : base(new EmptyFreeformRuleset())
-        {
-        }
+        protected override Ruleset CreatePlayerRuleset() => new EmptyFreeformRuleset();
     }
 }

--- a/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
+++ b/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform.Tests/osu.Game.Rulesets.EmptyFreeform.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Beatmaps/EmptyFreeformBeatmapConverter.cs
+++ b/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Beatmaps/EmptyFreeformBeatmapConverter.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.EmptyFreeform.Objects;
 using osu.Game.Rulesets.Objects;
@@ -21,7 +22,7 @@ namespace osu.Game.Rulesets.EmptyFreeform.Beatmaps
         // https://github.com/ppy/osu/tree/master/osu.Game/Rulesets/Objects/Types
         public override bool CanConvert() => true;
 
-        protected override IEnumerable<EmptyFreeformHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap)
+        protected override IEnumerable<EmptyFreeformHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             yield return new EmptyFreeformHitObject
             {

--- a/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Objects/Drawables/DrawableEmptyFreeformHitObject.cs
+++ b/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Objects/Drawables/DrawableEmptyFreeformHitObject.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.EmptyFreeform.Objects.Drawables
                 ApplyResult(r => r.Type = HitResult.Perfect);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             const double duration = 1000;
 

--- a/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Replays/EmptyFreeformFramedReplayInputHandler.cs
+++ b/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/Replays/EmptyFreeformFramedReplayInputHandler.cs
@@ -36,19 +36,16 @@ namespace osu.Game.Rulesets.EmptyFreeform.Replays
             }
         }
 
-        public override List<IInput> GetPendingInputs()
+        public override void CollectPendingInputs(List<IInput> inputs)
         {
-            return new List<IInput>
+            inputs.Add(new MousePositionAbsoluteInput
             {
-                new MousePositionAbsoluteInput
-                {
-                    Position = GamefieldToScreenSpace(Position),
-                },
-                new ReplayState<EmptyFreeformAction>
-                {
-                    PressedActions = CurrentFrame?.Actions ?? new List<EmptyFreeformAction>(),
-                }
-            };
+                Position = GamefieldToScreenSpace(Position),
+            });
+            inputs.Add(new ReplayState<EmptyFreeformAction>
+            {
+                PressedActions = CurrentFrame?.Actions ?? new List<EmptyFreeformAction>(),
+            });
         }
     }
 }

--- a/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/osu.Game.Rulesets.EmptyFreeform.csproj
+++ b/templates/ruleset-empty/osu.Game.Rulesets.EmptyFreeform/osu.Game.Rulesets.EmptyFreeform.csproj
@@ -10,7 +10,7 @@
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2020.515.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.109.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\Samples\Gameplay" />

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/TestSceneOsuPlayer.cs
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/TestSceneOsuPlayer.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.Pippidon.Tests
     [TestFixture]
     public class TestSceneOsuPlayer : PlayerTestScene
     {
-        public TestSceneOsuPlayer()
-            : base(new PippidonRuleset())
-        {
-        }
+        protected override Ruleset CreatePlayerRuleset() => new PippidonRuleset();
     }
 }

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
     <ItemGroup Label="Package References">
         <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+        <PackageReference Include="NUnit" Version="3.13.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
         <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
     </ItemGroup>
     <ItemGroup>

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -20,7 +21,7 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
 
         public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasPosition);
 
-        protected override IEnumerable<PippidonHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap)
+        protected override IEnumerable<PippidonHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             yield return new PippidonHitObject
             {

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Pippidon.Objects.Drawables
 
         protected override void UpdateInitialTransforms() => this.FadeInFromZero(time_fadein);
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             switch (state)
             {

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
@@ -42,13 +42,9 @@ namespace osu.Game.Rulesets.Pippidon.Objects.Drawables
             });
         }
 
-        protected override IEnumerable<HitSampleInfo> GetSamples() => new[]
+        public override IEnumerable<HitSampleInfo> GetSamples() => new[]
         {
-            new HitSampleInfo
-            {
-                Bank = SampleControlPoint.DEFAULT_BANK,
-                Name = HitSampleInfo.HIT_NORMAL,
-            }
+            new HitSampleInfo(HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK)
         };
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
@@ -35,15 +35,12 @@ namespace osu.Game.Rulesets.Pippidon.Replays
             }
         }
 
-        public override List<IInput> GetPendingInputs()
+        public override void CollectPendingInputs(List<IInput> inputs)
         {
-            return new List<IInput>
+            inputs.Add(new MousePositionAbsoluteInput
             {
-                new MousePositionAbsoluteInput
-                {
-                    Position = GamefieldToScreenSpace(Position)
-                }
-            };
+                Position = GamefieldToScreenSpace(Position)
+            });
         }
     }
 }

--- a/templates/ruleset-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
+++ b/templates/ruleset-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
@@ -10,6 +10,6 @@
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2020.515.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.109.0" />
   </ItemGroup>
 </Project>

--- a/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/TestSceneOsuPlayer.cs
+++ b/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/TestSceneOsuPlayer.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.EmptyScrolling.Tests
     [TestFixture]
     public class TestSceneOsuPlayer : PlayerTestScene
     {
-        public TestSceneOsuPlayer()
-            : base(new EmptyScrollingRuleset())
-        {
-        }
+        protected override Ruleset CreatePlayerRuleset() => new EmptyScrollingRuleset();
     }
 }

--- a/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
+++ b/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling.Tests/osu.Game.Rulesets.EmptyScrolling.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Beatmaps/EmptyScrollingBeatmapConverter.cs
+++ b/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Beatmaps/EmptyScrollingBeatmapConverter.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.EmptyScrolling.Objects;
@@ -19,7 +20,7 @@ namespace osu.Game.Rulesets.EmptyScrolling.Beatmaps
         // https://github.com/ppy/osu/tree/master/osu.Game/Rulesets/Objects/Types
         public override bool CanConvert() => true;
 
-        protected override IEnumerable<EmptyScrollingHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap)
+        protected override IEnumerable<EmptyScrollingHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             yield return new EmptyScrollingHitObject
             {

--- a/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Objects/Drawables/DrawableEmptyScrollingHitObject.cs
+++ b/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Objects/Drawables/DrawableEmptyScrollingHitObject.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.EmptyScrolling.Objects.Drawables
                 ApplyResult(r => r.Type = HitResult.Perfect);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             const double duration = 1000;
 

--- a/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Replays/EmptyScrollingFramedReplayInputHandler.cs
+++ b/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/Replays/EmptyScrollingFramedReplayInputHandler.cs
@@ -18,15 +18,12 @@ namespace osu.Game.Rulesets.EmptyScrolling.Replays
 
         protected override bool IsImportant(EmptyScrollingReplayFrame frame) => frame.Actions.Any();
 
-        public override List<IInput> GetPendingInputs()
+        public override void CollectPendingInputs(List<IInput> inputs)
         {
-            return new List<IInput>
+            inputs.Add(new ReplayState<EmptyScrollingAction>
             {
-                new ReplayState<EmptyScrollingAction>
-                {
-                    PressedActions = CurrentFrame?.Actions ?? new List<EmptyScrollingAction>(),
-                }
-            };
+                PressedActions = CurrentFrame?.Actions ?? new List<EmptyScrollingAction>(),
+            });
         }
     }
 }

--- a/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/osu.Game.Rulesets.EmptyScrolling.csproj
+++ b/templates/ruleset-scrolling-empty/osu.Game.Rulesets.EmptyScrolling/osu.Game.Rulesets.EmptyScrolling.csproj
@@ -10,7 +10,7 @@
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2020.515.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.109.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\Samples\Gameplay" />

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/TestSceneOsuPlayer.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/TestSceneOsuPlayer.cs
@@ -9,9 +9,6 @@ namespace osu.Game.Rulesets.Pippidon.Tests
     [TestFixture]
     public class TestSceneOsuPlayer : PlayerTestScene
     {
-        public TestSceneOsuPlayer()
-            : base(new PippidonRuleset())
-        {
-        }
+        protected override Ruleset CreatePlayerRuleset() => new PippidonRuleset();
     }
 }

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon.Tests/osu.Game.Rulesets.Pippidon.Tests.csproj
@@ -10,9 +10,9 @@
     </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Update="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup>

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -26,7 +27,7 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
 
         public override bool CanConvert() => Beatmap.HitObjects.All(h => h is IHasXPosition && h is IHasYPosition);
 
-        protected override IEnumerable<PippidonHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap)
+        protected override IEnumerable<PippidonHitObject> ConvertHitObject(HitObject original, IBeatmap beatmap, CancellationToken cancellationToken)
         {
             yield return new PippidonHitObject
             {

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
@@ -53,7 +53,7 @@ namespace osu.Game.Rulesets.Pippidon.Objects.Drawables
                 ApplyResult(r => r.Type = currentLane.Value == HitObject.Lane ? HitResult.Perfect : HitResult.Miss);
         }
 
-        protected override void UpdateStateTransforms(ArmedState state)
+        protected override void UpdateHitStateTransforms(ArmedState state)
         {
             switch (state)
             {

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Objects/Drawables/DrawablePippidonHitObject.cs
@@ -42,13 +42,9 @@ namespace osu.Game.Rulesets.Pippidon.Objects.Drawables
             currentLane = playfield.CurrentLane.GetBoundCopy();
         }
 
-        protected override IEnumerable<HitSampleInfo> GetSamples() => new[]
+        public override IEnumerable<HitSampleInfo> GetSamples() => new[]
         {
-            new HitSampleInfo
-            {
-                Bank = SampleControlPoint.DEFAULT_BANK,
-                Name = HitSampleInfo.HIT_NORMAL,
-            }
+            new HitSampleInfo(HitSampleInfo.HIT_NORMAL, SampleControlPoint.DEFAULT_BANK)
         };
 
         protected override void CheckForResult(bool userTriggered, double timeOffset)

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Replays/PippidonFramedReplayInputHandler.cs
@@ -18,15 +18,12 @@ namespace osu.Game.Rulesets.Pippidon.Replays
 
         protected override bool IsImportant(PippidonReplayFrame frame) => frame.Actions.Any();
 
-        public override List<IInput> GetPendingInputs()
+        public override void CollectPendingInputs(List<IInput> inputs)
         {
-            return new List<IInput>
+            inputs.Add(new ReplayState<PippidonAction>
             {
-                new ReplayState<PippidonAction>
-                {
-                    PressedActions = CurrentFrame?.Actions ?? new List<PippidonAction>(),
-                }
-            };
+                PressedActions = CurrentFrame?.Actions ?? new List<PippidonAction>(),
+            });
         }
     }
 }

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/UI/PippidonCharacter.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/UI/PippidonCharacter.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Pippidon.UI
             LanePosition.BindValueChanged(e => { this.MoveToY(e.NewValue * PippidonPlayfield.LANE_HEIGHT); });
         }
 
-        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
+        protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
         {
             if (effectPoint.KiaiMode)
             {

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/UI/PippidonPlayfield.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/UI/PippidonPlayfield.cs
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Pippidon.UI
                 }
             }
 
-            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, TrackAmplitudes amplitudes)
+            protected override void OnNewBeat(int beatIndex, TimingControlPoint timingPoint, EffectControlPoint effectPoint, ChannelAmplitudes amplitudes)
             {
                 if (effectPoint.KiaiMode)
                     fill.FlashColour(colours.PinkLight, 800, Easing.In);

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/osu.Game.Rulesets.Pippidon.csproj
@@ -10,6 +10,6 @@
     <EmbeddedResource Include="Resources\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2020.515.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.109.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Templates haven't been updated since May of last year. Minimal set of changes to make the templates build cleanly. I could do more (around the area of hit result unification, for one), but just want to have this build with latest game at least for now.

First step towards #31 but clearly doing this manually is untenable long term.