### PR TITLE
Fix lanes

### DIFF
--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Beatmaps/PippidonBeatmapConverter.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Pippidon.Beatmaps
         }
 
         private int getLane(HitObject hitObject) => (int)MathHelper.Clamp(
-            (getUsablePosition(hitObject) - minPosition) / (maxPosition - minPosition) * PippidonPlayfield.LANE_COUNT, 0, PippidonPlayfield.LANE_COUNT);
+            (getUsablePosition(hitObject) - minPosition) / (maxPosition - minPosition) * PippidonPlayfield.LANE_COUNT, 0, PippidonPlayfield.LANE_COUNT - 1);
 
         private float getUsablePosition(HitObject h) => (h as IHasYPosition)?.Y ?? ((IHasXPosition)h).X;
     }

--- a/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Replays/PippidonAutoGenerator.cs
+++ b/templates/ruleset-scrolling-example/osu.Game.Rulesets.Pippidon/Replays/PippidonAutoGenerator.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Rulesets.Pippidon.Replays
 
                 double time = hitObject.StartTime - 5;
 
-                if (totalTravel == PippidonPlayfield.LANE_COUNT)
+                if (totalTravel == PippidonPlayfield.LANE_COUNT - 1)
                     addFrame(time, direction == PippidonAction.MoveDown ? PippidonAction.MoveUp : PippidonAction.MoveDown);
                 else
                 {


### PR DESCRIPTION
Fix hitObject appearing on unreachable lane:
  MathHelper.Clamp returns value inclusively, this out of lanes range and leads creating hitObject in the non-existent lane.
Fix character to move in a shorter distance:
  If the hitObject on the top lane and next on the lowest lane, the character will move up and vice versa.